### PR TITLE
Quarter label

### DIFF
--- a/src/rules/__init__.py
+++ b/src/rules/__init__.py
@@ -1,3 +1,4 @@
+from .due_date import check_due_date
 from .parent import check_parent_link
 from .priority import check_priority
 from .rank import check_rank

--- a/src/rules/__init__.py
+++ b/src/rules/__init__.py
@@ -1,5 +1,6 @@
 from .due_date import check_due_date
 from .parent import check_parent_link
 from .priority import check_priority
+from .quarter_label import check_quarter_label
 from .rank import check_rank
 from .target_dates import check_target_dates

--- a/src/rules/due_date.py
+++ b/src/rules/due_date.py
@@ -1,0 +1,31 @@
+import jira
+from time import strftime
+from utils.jira import refresh, update
+
+today = strftime("%Y-%m-%d")
+
+
+def check_due_date(issue: jira.resources.Issue, context: dict, dry_run: bool) -> None:
+    related_issues = list(issue.raw["Context"]["Related Issues"]["Blocks"])
+    parent_issue = issue.raw["Context"]["Related Issues"]["Parent"]
+    if parent_issue is not None:
+        related_issues.append(parent_issue)
+    if not related_issues:
+        return
+
+    due_date_id = issue.raw["Context"]["Field Ids"]["Due Date"]
+    target_due_date = None
+    for i in related_issues:
+        related_due_date = getattr(i.fields, due_date_id)
+        if related_due_date is None:
+            continue
+        if not target_due_date or target_due_date > related_due_date:
+            target_due_date = related_due_date
+
+    due_date = getattr(issue.fields, due_date_id)
+    if (target_due_date is None and due_date) or (
+        target_due_date and (not due_date or due_date != target_due_date)
+    ):
+        context["updates"].append(f"  > Updating Due Date to {target_due_date}.")
+        if not dry_run:
+            update(issue, {"fields": {due_date_id: target_due_date}})

--- a/src/rules/quarter_label.py
+++ b/src/rules/quarter_label.py
@@ -1,0 +1,31 @@
+import jira
+from re import compile
+from time import strftime
+from utils.jira import update
+
+today = strftime("%Y-%m-%d")
+
+
+def check_quarter_label(
+    issue: jira.resources.Issue, context: dict, dry_run: bool
+) -> None:
+    parent_issue = issue.raw["Context"]["Related Issues"]["Parent"]
+    if parent_issue is None:
+        return
+
+    updated = False
+    re_quarter = compile("[0-9]{4}Q[1-4]")
+    for label in parent_issue.fields.labels:
+        if re_quarter.match(label) and label not in issue.fields.labels:
+            context["updates"].append(f"  > Adding label: {label}.")
+            if not dry_run:
+                issue.fields.labels.append(label)
+                updated = True
+    for label in issue.fields.labels:
+        if re_quarter.match(label) and label not in parent_issue.fields.labels:
+            context["updates"].append(f"  < Removing label: {label}.")
+            if not dry_run:
+                issue.fields.labels.remove(label)
+                updated = True
+    if updated:
+        update(issue, {"fields": {"labels": issue.fields.labels}})

--- a/src/rules/target_dates.py
+++ b/src/rules/target_dates.py
@@ -3,27 +3,22 @@ from time import strftime
 
 today = strftime("%Y-%m-%d")
 
-def check_target_dates(issue: jira.resources.Issue, context: dict, dry_run: bool) -> None:
-    start_date_id = issue.raw["Context"]["Field Ids"]["Target Start"]
-    end_date_id = issue.raw["Context"]["Field Ids"]["Target End"]
+
+def check_target_dates(
+    issue: jira.resources.Issue, context: dict, dry_run: bool
+) -> None:
+    start_date_id = issue.raw["Context"]["Field Ids"]["Target Start Date"]
+    end_date_id = issue.raw["Context"]["Field Ids"]["Target End Date"]
     start_date = getattr(issue.fields, start_date_id)
     end_date = getattr(issue.fields, end_date_id)
     if start_date:
         if start_date < today and issue.fields.status in ["New", "Refinement"]:
-            context["updates"].append(
-                f"  > Issue Target Start Date is obsolete."
-            )
+            context["updates"].append(f"  > Issue Target Start Date Date is obsolete.")
     else:
-        context["updates"].append(
-            f"  > Issue Target Start Date unset."
-        )
+        context["updates"].append(f"  * Issue Target Start Date Date unset.")
     if end_date:
         # Query ensure the issue is not closed
         if end_date < today:
-            context["updates"].append(
-            f"  > Issue Target End Date is obsolete."
-        )
+            context["updates"].append(f"  * Issue Target End Date Date is obsolete.")
     else:
-        context["updates"].append(
-            f"  > Issue Target End Date unset."
-        )
+        context["updates"].append(f"  * Issue Target End Date Date unset.")

--- a/src/team_hygiene.py
+++ b/src/team_hygiene.py
@@ -66,6 +66,7 @@ def main(dry_run: bool, project_id: str, token: str, url: str) -> None:
     config["Story"] = [
         rules.check_parent_link,
         rules.check_priority,
+        rules.check_quarter_label,
         rules.check_due_date,
     ]
 

--- a/src/team_hygiene.py
+++ b/src/team_hygiene.py
@@ -57,8 +57,17 @@ def main(dry_run: bool, project_id: str, token: str, url: str) -> None:
     jira_client = jira.client.JIRA(server=url, token_auth=token)
 
     config = OrderedDict()
-    config["Epic"] = [rules.check_parent_link, rules.check_priority, rules.check_target_dates]
-    config["Story"] = [rules.check_parent_link, rules.check_priority]
+    config["Epic"] = [
+        rules.check_parent_link,
+        rules.check_priority,
+        rules.check_due_date,
+        rules.check_target_dates,
+    ]
+    config["Story"] = [
+        rules.check_parent_link,
+        rules.check_priority,
+        rules.check_due_date,
+    ]
 
     context = {
         "issues": get_issues(jira_client, project_id, config.keys()),
@@ -71,7 +80,10 @@ def main(dry_run: bool, project_id: str, token: str, url: str) -> None:
 
 
 def process_type(
-    jira_client: jira.client.JIRA, issues: list[jira.resources.Issue], checks: list[callable], dry_run: bool
+    jira_client: jira.client.JIRA,
+    issues: list[jira.resources.Issue],
+    checks: list[callable],
+    dry_run: bool,
 ) -> None:
     count = len(issues)
     for index, issue in enumerate(issues):

--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -58,8 +58,13 @@ def get_fields_ids(
     ids["Parent Link"] = get_parent_link_field_id(issues, candidates)
 
     ids["Rank"] = [f["id"] for f in all_the_fields if f["name"] == "Rank"][0]
-    ids["Target Start"] = [f["id"] for f in all_the_fields if f["name"] == "Target start"][0]
-    ids["Target End"] = [f["id"] for f in all_the_fields if f["name"] == "Target end"][0]
+    ids["Target Start Date"] = [
+        f["id"] for f in all_the_fields if f["name"] == "Target start"
+    ][0]
+    ids["Target End Date"] = [
+        f["id"] for f in all_the_fields if f["name"] == "Target end"
+    ][0]
+    ids["Due Date"] = [f["id"] for f in all_the_fields if f["name"] == "Due Date"][0]
 
     return ids
 

--- a/tools/release/hack/run.sh
+++ b/tools/release/hack/run.sh
@@ -69,7 +69,7 @@ enter_container() {
         --rm \
         --volume "$PROJECT_DIR":"/workspace":Z \
         "$IMAGE_TAG" \
-        "/workspace/src/jira_hygiene.py" "${OPTIONS[@]}"
+        "/workspace/src/team_hygiene.py" "${OPTIONS[@]}"
 }
 
 main() {


### PR DESCRIPTION
Propagate YYYYQ# labels from Epics to issues.

This might be replaced in the future by the propagation of the `Fix Version` instead.