### PR TITLE
Create and set the Release related to the Outcome

### DIFF
--- a/src/rules/__init__.py
+++ b/src/rules/__init__.py
@@ -1,4 +1,5 @@
 from .due_date import check_due_date
+from .outcome_version import set_fix_version
 from .parent import check_parent_link
 from .priority import check_priority
 from .quarter_label import check_quarter_label

--- a/src/rules/due_date.py
+++ b/src/rules/due_date.py
@@ -37,4 +37,6 @@ def check_due_date(issue: jira.resources.Issue, context: dict, dry_run: bool) ->
     end_date_id = issue.raw["Context"]["Field Ids"]["Target End Date"]
     end_date = getattr(issue.fields, end_date_id)
     if end_date and target_due_date and end_date > target_due_date:
-        context["updates"].append(f"  ? Target Date exceeds Due Date. You may want to notify the Program Managers.")
+        context["updates"].append(
+            f"  ? Target Date exceeds Due Date. You may want to notify the Program Managers."
+        )

--- a/src/rules/outcome_version.py
+++ b/src/rules/outcome_version.py
@@ -1,0 +1,9 @@
+import jira
+
+
+def set_fix_version(issue: jira.resources.Issue, context: dict, _: bool) -> None:
+    parent_issue = issue.raw["Context"]["Related Issues"]["Parent"]
+    if parent_issue is None:
+        return
+    print(parent_issue, dir(parent_issue))
+    0/0

--- a/src/rules/outcome_version.py
+++ b/src/rules/outcome_version.py
@@ -1,9 +1,47 @@
 import jira
+from re import compile
+
+import utils.jira
 
 
-def set_fix_version(issue: jira.resources.Issue, context: dict, _: bool) -> None:
+def set_fix_version(issue: jira.resources.Issue, context: dict, dry_run: bool) -> None:
     parent_issue = issue.raw["Context"]["Related Issues"]["Parent"]
     if parent_issue is None:
         return
-    print(parent_issue, dir(parent_issue))
-    0/0
+    utils.jira.preprocess(context["jira_client"], [parent_issue])
+    outcome_issue = utils.jira.get_parent(context["jira_client"], parent_issue)
+    if outcome_issue is None or outcome_issue.fields.issuetype.name != "Outcome":
+        version_name = None
+    else:
+        version_name = outcome_issue.key
+
+    fix_versions = getattr(issue.fields, "fixVersions", [])
+    updated = False
+
+    re_issue_key = compile("[A-Z]*-[0-9]*")
+    for fv in fix_versions.copy():
+        if re_issue_key.match(fv.name) and fv.name != version_name:
+            updated = True
+            fix_versions.remove(fv)
+            context["updates"].append(f"  > Removing Fix Version: {fv.name}.")
+
+    if version_name and version_name not in [fv.name for fv in fix_versions]:
+        updated = True
+        context["updates"].append(f"  > Adding Fix Version: {version_name}.")
+        version = utils.jira.get_version(
+            context["jira_client"],
+            issue.key.split("-")[0],
+            outcome_issue.key,
+            outcome_issue.fields.summary,
+        )
+        fix_versions.append(version)
+
+    if updated and not dry_run:
+        utils.jira.update(
+            issue,
+            {
+                "fields": {
+                    "fixVersions": [{"name": fv.name} for fv in fix_versions],
+                },
+            },
+        )

--- a/src/team_hygiene.py
+++ b/src/team_hygiene.py
@@ -62,6 +62,7 @@ def main(dry_run: bool, project_id: str, token: str, url: str) -> None:
         rules.check_priority,
         rules.check_due_date,
         rules.check_target_dates,
+        rules.set_fix_version,
     ]
     config["Story"] = [
         rules.check_parent_link,

--- a/src/team_hygiene.py
+++ b/src/team_hygiene.py
@@ -70,12 +70,9 @@ def main(dry_run: bool, project_id: str, token: str, url: str) -> None:
         rules.check_due_date,
     ]
 
-    context = {
-        "issues": get_issues(jira_client, project_id, config.keys()),
-    }
-
-    for issue_type, issues in context["issues"].items():
+    for issue_type in config.keys():
         print(f"\n\n## Processing {issue_type}")
+        issues = get_issues(jira_client, project_id, [issue_type])
         process_type(jira_client, issues, config[issue_type], dry_run)
     print("\nDone.")
 

--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -5,12 +5,11 @@ import jira
 
 def get_issues(
     jira_client: jira.client.JIRA, project_id: str, issue_types: list[str]
-) -> dict:
-    result = {}
+) -> list:
+    result = []
     for issue_type in issue_types:
-        issues = query_issues(jira_client, project_id, issue_type)
-        preprocess(jira_client, issues)
-        result[issue_type] = issues
+        result += query_issues(jira_client, project_id, issue_type)
+    preprocess(jira_client, result)
     return result
 
 

--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -101,6 +101,18 @@ def get_blocks(jira_client: jira.client.JIRA, issue: jira.resources.Issue):
     return blocks
 
 
+def get_version(
+    jira_client: jira.client.JIRA, project_key: str, version: str, description: str
+):
+    versions = jira_client.project_versions(project_key)
+    for v in versions:
+        if version == v.name:
+            return v
+    return jira_client.create_version(
+        project=project_key, name=version, description=description
+    )
+
+
 def refresh(issue: jira.resources.Issue) -> None:
     update(issue, {})
 


### PR DESCRIPTION
The goal of this rule is to be able to easily track the progress of a particular outcome within a team by linking Epics to an Outcome through the use of a Release.

Every Epic linked to an Outcome will be added to a Release which name is the Outcome key and description is the Outcome title.

Epics are automatically added/removed from the Releases as issues are moved around.

The Release page in JIRA provides a quick overview of all the Outcomes a team is participating in, as well as the current progress.