### PR TITLE
Fix get_children

### DIFF
--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -118,7 +118,7 @@ def get_blocks(jira_client: jira.client.JIRA, issue: jira.resources.Issue):
 
 
 def get_children(jira_client: jira.client.JIRA, issue: jira.resources.Issue):
-    query = f'issue in linkedIssues("{issue.key}", "is parent of")'
+    query = f'"Parent Link" = {issue.key} or "Epic Link" = {issue.key}'
     return _search(jira_client, query, verbose=False)
 
 


### PR DESCRIPTION
Before this, it would fail to gather Epics which are children of a Feature.