### PR TITLE
Change logic for setting compliance flag

### DIFF
--- a/src/automation.py
+++ b/src/automation.py
@@ -12,6 +12,7 @@ import os
 
 import click
 import jira
+
 from utils.configuration import Config
 from utils.jira import set_non_compliant_flag
 
@@ -84,6 +85,7 @@ def process_type(
             "comments": [],
             "jira_client": jira_client,
             "updates": [],
+            "non-compliant": False,
         }
         for check in checks:
             check(issue, context, dry_run)

--- a/src/rules/team/parent.py
+++ b/src/rules/team/parent.py
@@ -3,4 +3,5 @@ import jira
 
 def check_parent_link(issue: jira.resources.Issue, context: dict, _: bool) -> None:
     if issue.raw["Context"]["Related Issues"]["Parent"] is None:
+        context["non-compliant"] = True
         context["comments"].append(f"  * Issue is missing the link to its parent.")

--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -166,13 +166,17 @@ def set_non_compliant_flag(
     if context["comments"]:
         print("\n".join(context["comments"]))
     if not dry_run:
-        if context["comments"]:
-            if has_non_compliant_flag:
+        if has_non_compliant_flag:
+            if context["comments"]:
+                # If the issue is already marked, don't spam with more comments
                 context["comments"].clear()
-            else:
+
+            if not context["non-compliant"]:
+                # If the issue looks good now, then unmark it.
+                issue.fields.labels.remove(non_compliant_flag)
+                update(issue, {"fields": {"labels": issue.fields.labels}})
+                context["comments"].append("  * Issue is now compliant")
+        else:
+            if context["non-compliant"]:
                 issue.fields.labels.append(non_compliant_flag)
                 update(issue, {"fields": {"labels": issue.fields.labels}})
-        elif not context["comments"] and has_non_compliant_flag:
-            issue.fields.labels.remove(non_compliant_flag)
-            update(issue, {"fields": {"labels": issue.fields.labels}})
-            context["comments"].append("  * Issue is now compliant")


### PR DESCRIPTION
Previously, the logic used the presence or absence of comments as the parameter to trigger whether or not an issue should be marked as non-compliant or not.

It just so happened that before, the _only_ rule that added a comment happened to be one that needed this behavior.

In 271f8a9, we added comments to two more rules - but these rules had behavior that automatically brought the issue into compliance. There was no need to set and then later unset the flag.

This change adds a new field to the context "non-compliant" that defaults to False. A rule needs to explicitly set that to true in order to request that the issue be updated with the flag.